### PR TITLE
Refactor how symbol and variable names are managed

### DIFF
--- a/benches/criterion.rs
+++ b/benches/criterion.rs
@@ -12,128 +12,51 @@ macro_rules! sanity_check {
 fn prepare_zebra(reverse: bool) -> TextualUniverse {
     let mut u = TextualUniverse::new();
 
-    u.load_str(
-        r#"
-        exists($0,list($0,$1,$2,$3,$4)).
-        exists($1,list($0,$1,$2,$3,$4)).
-        exists($2,list($0,$1,$2,$3,$4)).
-        exists($3,list($0,$1,$2,$3,$4)).
-        exists($4,list($0,$1,$2,$3,$4)).
-        rightOf($1,$0,list($0,$1,$2,$3,$4)).
-        rightOf($2,$1,list($0,$1,$2,$3,$4)).
-        rightOf($3,$2,list($0,$1,$2,$3,$4)).
-        rightOf($4,$3,list($0,$1,$2,$3,$4)).
-        middle($2,list($0,$1,$2,$3,$4)).
-        first($0,list($0,$1,$2,$3,$4)).
-        nextTo($1,$0,list($0,$1,$2,$3,$4)).
-        nextTo($2,$1,list($0,$1,$2,$3,$4)).
-        nextTo($3,$2,list($0,$1,$2,$3,$4)).
-        nextTo($4,$3,list($0,$1,$2,$3,$4)).
-        nextTo($0,$1,list($0,$1,$2,$3,$4)).
-        nextTo($1,$2,list($0,$1,$2,$3,$4)).
-        nextTo($2,$3,list($0,$1,$2,$3,$4)).
-        nextTo($3,$4,list($0,$1,$2,$3,$4)).
-    "#,
-    )
-    .unwrap();
-
     if reverse {
-        u.load_str(
-            r#"
-            puzzle($0) :-
-                exists(house($65,$66,$67,$68,zebra),$0),
-                exists(house($61,$62,water,$63,$64),$0),
-                nextTo(house($53,$54,$55,diplomat,$56),house($57,$58,$59,$60,horse),$0),
-                nextTo(house($45,$46,$47,physician,$48),house($49,$50,$51,$52,fox),$0),
-                exists(house($42,$43,juice,violinist,$44),$0),
-                nextTo(house($13,norway,$14,$15,$16),house(blue,$38,$39,$40,$41),$0),
-                exists(house(green,$35,coffee,$36,$37),$0),
-                middle(house($31,$32,milk,$33,$34),$0),
-                exists(house(yellow,$28,$29,diplomat,$30),$0),
-                exists(house($25,$26,$27,photographer,snails),$0),
-                rightOf(house(green,$17,$18,$19,$20),house(white,$21,$22,$23,$24),$0),
-                first(house($13,norway,$14,$15,$16),$0),
-                exists(house($10,italy,tea,$11,$12),$0),
-                exists(house($7,japan,$8,painter,$9),$0),
-                exists(house($4,spain,$5,$6,dog),$0),
-                exists(house(red,england,$1,$2,$3),$0).
-        "#,
-        )
-        .unwrap();
+        u.load_str(include_str!("../testfiles/zebra-reverse.lru"))
+            .unwrap();
     } else {
-        u.load_str(
-            r#"
-        puzzle($0) :-
-            exists(house(red,england,$1,$2,$3),$0),
-            exists(house($4,spain,$5,$6,dog),$0),
-            exists(house($7,japan,$8,painter,$9),$0),
-            exists(house($10,italy,tea,$11,$12),$0),
-            first(house($13,norway,$14,$15,$16),$0),
-            rightOf(house(green,$17,$18,$19,$20),house(white,$21,$22,$23,$24),$0),
-            exists(house($25,$26,$27,photographer,snails),$0),
-            exists(house(yellow,$28,$29,diplomat,$30),$0),
-            middle(house($31,$32,milk,$33,$34),$0),
-            exists(house(green,$35,coffee,$36,$37),$0),
-            nextTo(house($13,norway,$14,$15,$16),house(blue,$38,$39,$40,$41),$0),
-            exists(house($42,$43,juice,violinist,$44),$0),
-            nextTo(house($45,$46,$47,physician,$48),house($49,$50,$51,$52,fox),$0),
-            nextTo(house($53,$54,$55,diplomat,$56),house($57,$58,$59,$60,horse),$0),
-            exists(house($61,$62,water,$63,$64),$0),
-            exists(house($65,$66,$67,$68,zebra),$0).
-    "#,
-        )
-        .unwrap();
+        u.load_str(include_str!("../testfiles/zebra.lru")).unwrap();
     }
 
     u
 }
 
 fn zebra(u: &mut TextualUniverse) -> usize {
-    let solutions = u.query_dfs("puzzle($0).").unwrap();
+    let solutions = u.query_dfs("puzzle(X).").unwrap();
     sanity_check!(solutions.count(), 1)
 }
 
 fn prepare_arithmetic() -> TextualUniverse {
     let mut u = TextualUniverse::new();
 
-    u.load_str(
-        r#"
-    is_natural(z).
-    is_natural(s($0)) :- is_natural($0).
-
-    add($0, z, $0) :- is_natural($0).
-    add($0, s($1), s($2)) :- add($0, $1, $2).
-
-    mul($0, z, z) :- is_natural($0).
-    mul($0, s($1), $2) :- mul($0,$1,$3), add($0,$3,$2).
-    "#,
-    )
-    .unwrap();
+    u.load_str(include_str!("../testfiles/arithmetic.lru"))
+        .unwrap();
     u
 }
 
 fn arithmetic_add(u: &mut TextualUniverse) -> usize {
-    let solutions = u.query_dfs("add(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(z))))))))))))))))),s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(z))))))))))))))))),$0).").unwrap();
+    let solutions = u.query_dfs("add(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(z))))))))))))))))),s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(z))))))))))))))))),X).").unwrap();
     sanity_check!(solutions.count(), 1)
 }
 
 fn arithmetic_add_reverse(u: &mut TextualUniverse) -> usize {
-    let solutions = u.query_dfs("add($0,$1,s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(z))))))))))))))))))))))))))))))))))).").unwrap();
+    let solutions = u.query_dfs("add(X,Y,s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(z))))))))))))))))))))))))))))))))))).").unwrap();
     sanity_check!(solutions.count(), 35)
 }
 
 fn arithmetic_sub(u: &mut TextualUniverse) -> usize {
-    let solutions = u.query_dfs("add($0,s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(z))))))))))))))))),s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(z))))))))))))))))))))))))))))))))))).").unwrap();
+    let solutions = u.query_dfs("add(X,s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(z))))))))))))))))),s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(z))))))))))))))))))))))))))))))))))).").unwrap();
     sanity_check!(solutions.count(), 1)
 }
 
 fn arithmetic_mul(u: &mut TextualUniverse) -> usize {
-    let solutions = u.query_dfs("mul(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(z))))))))))))))))),s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(z))))))))))))))))),$0).").unwrap();
+    let solutions = u.query_dfs("mul(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(z))))))))))))))))),s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(s(z))))))))))))))))),X).").unwrap();
     sanity_check!(solutions.count(), 1)
 }
 
 fn arithmetic_squares(u: &mut TextualUniverse) -> usize {
-    let solutions = u.query_dfs("mul($0,$0,$1).").unwrap();
+    let solutions = u.query_dfs("mul(X,X,Y).").unwrap();
     sanity_check!(solutions.take(40).count(), 40)
 }
 

--- a/examples/arithmetic.rs
+++ b/examples/arithmetic.rs
@@ -3,28 +3,21 @@ use logru::{solver::query_dfs, textual::TextualUniverse};
 fn main() {
     let mut u = TextualUniverse::new();
 
-    u.load_str(
-        r#"
-    is_natural(z).
-    is_natural(s($0)) :- is_natural($0).
+    u.load_str(include_str!("../testfiles/arithmetic.lru"))
+        .unwrap();
 
-    add($0, z, $0) :- is_natural($0).
-    add($0, s($1), s($2)) :- add($0, $1, $2).
-
-    mul($0, z, z) :- is_natural($0).
-    mul($0, s($1), $2) :- mul($0,$1,$3), add($0,$3,$2).
-    "#,
-    )
-    .unwrap();
-
-    let query = u.prepare_query("mul($0,$0,$1).").unwrap();
-    let solutions = query_dfs(u.inner(), &query);
+    let query = u.prepare_query("mul(A,A,B).").unwrap();
+    let solutions = query_dfs(u.rules(), &query);
 
     for solution in solutions.take(10) {
         println!("SOLUTION:");
         for (index, var) in solution.into_iter().enumerate() {
             if let Some(term) = var {
-                println!("  ${} = {}", index, u.pretty().term_to_string(&term));
+                println!(
+                    "  ${} = {}",
+                    index,
+                    u.pretty().term_to_string(&term, query.scope.as_ref())
+                );
             } else {
                 println!("<bug: no solution>");
             }

--- a/examples/zebra.rs
+++ b/examples/zebra.rs
@@ -9,9 +9,9 @@ fn main() {
     let mut u = logru::textual::TextualUniverse::new();
     u.load_str(include_str!("../testfiles/zebra.lru")).unwrap();
 
-    let query = u.prepare_query("puzzle($0).").unwrap();
+    let query = u.prepare_query("puzzle(Houses).").unwrap();
     for _ in 0..repeats {
-        let search = logru::query_dfs(u.inner(), &query);
+        let search = logru::query_dfs(u.rules(), &query);
         let before = Instant::now();
         let solutions = search.collect::<Vec<_>>();
         let duration = before.elapsed();
@@ -19,7 +19,7 @@ fn main() {
         for solution in solutions.iter() {
             for var in solution {
                 if let Some(term) = var {
-                    println!("{}", u.pretty().term_to_string(term));
+                    println!("{}", u.pretty().term_to_string(term, query.scope.as_ref()));
                 } else {
                     println!("<bug: no solution>");
                 }

--- a/src/term_arena.rs
+++ b/src/term_arena.rs
@@ -1,7 +1,7 @@
 //! # Arena allocation for terms
 //!
 //! This module provides an alternative representation for logic terms that is more efficient to
-//! work with in the solver than the one from the [`ast`](crate::ast) module.
+//! work with in the solver than the one from the [`ast`] module.
 //!
 //! It's not used for the "external" interface because while being more efficient in certain cases,
 //! the interface is also more cumbersome to use. As a trade-off, conversion happens at interface

--- a/src/textual.rs
+++ b/src/textual.rs
@@ -2,127 +2,39 @@
 //!
 //! This module provides a textual, Prolog-like syntax for the solver core. See [`TextualUniverse`]
 //! for an example.
-//!
-//! As a lower-level abstraction, this module also provides [`NamedUniverse`] which doesn't come
-//! with a full-blown parse, but does provide a name mapping for symbols.
 
 mod lexer;
 mod parser;
 mod pretty;
 
-use std::collections::HashMap;
-
 pub use parser::{ParseError, ParseErrorKind};
 
 use crate::{
-    ast::{Query, Sym},
+    ast::Query,
     solver::{self, SolutionIter},
-    universe::Universe,
+    universe::{CompiledRuleDb, SymbolStore},
 };
 
 pub use self::{parser::Parser, pretty::Prettifier};
 
-/// A universe where symbols have literal names.
-///
-/// It wraps an underlying [`Universe`] and maintains a mapping between names and symbols so that
-/// for each symbol created via this wrapper, the name can be looked up, and each symbol is created
-/// by name.
-///
-/// # Example
-///
-/// ```
-/// # use logru::textual::*;
-/// let mut nu = NamedUniverse::new();
-/// let foo = nu.symbol("foo");
-/// let bar = nu.symbol("bar");
-/// assert_ne!(foo, bar);
-///
-/// let foo_again = nu.symbol("foo");
-/// assert_eq!(foo, foo_again);
-///
-/// let bar_name = nu.symbol_name(bar);
-/// assert_eq!(bar_name, Some("bar"));
-///
-/// // Creating an unnamed symbol
-/// let unknown = nu.inner_mut().alloc_symbol();
-/// let unknown_name = nu.symbol_name(unknown);
-/// assert_eq!(unknown_name, None);
-/// ```
-///
-pub struct NamedUniverse {
-    names: HashMap<String, Sym>,
-    syms: HashMap<Sym, String>,
-    universe: Universe,
-}
-
-impl NamedUniverse {
-    /// Create a new empty universe.
-    pub fn new() -> Self {
-        Self {
-            names: HashMap::new(),
-            syms: HashMap::new(),
-            universe: Universe::new(),
-        }
-    }
-
-    /// Create a new symbol or return an existing symbol with that name
-    ///
-    /// Each symbol with a given name can exist only once. When an existing name is passed to this
-    /// function, the existing symbol identifier is returned.
-    pub fn symbol(&mut self, name: &str) -> Sym {
-        if let Some(sym) = self.names.get(name) {
-            *sym
-        } else {
-            let sym = self.universe.alloc_symbol();
-            self.names.insert(name.to_owned(), sym);
-            self.syms.insert(sym, name.to_owned());
-            sym
-        }
-    }
-
-    /// Look up the name of a symbol.
-    ///
-    /// A symbol may have no name if it was created directly via the underlying universe using
-    /// [`NamedUniverse::inner_mut`].
-    pub fn symbol_name(&self, sym: Sym) -> Option<&str> {
-        self.syms.get(&sym).map(|s| s.as_str())
-    }
-
-    /// Get mutable access to the underlying universe.
-    pub fn inner_mut(&mut self) -> &mut Universe {
-        &mut self.universe
-    }
-
-    /// Get shared access to the underlying universe.
-    pub fn inner(&self) -> &Universe {
-        &self.universe
-    }
-}
-
-impl Default for NamedUniverse {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 /// A universe that can be interacted with using a Prolog like syntax.
 ///
-/// It builds on the [`NamedUniverse`] abstraction and additionally provides a fully textual syntax
-/// for defining rules and queries, looking very similar to Prolog. Variables are still referenced
-/// by numeric IDs though, but this is subject to change in future versions.
+/// It builds on the [`SymbolStore`] and [`CompiledRuleDb`] abstractions and additionally provides a
+/// fully textual syntax for defining rules and queries, looking very similar to Prolog.
 ///
 /// Syntactic elements:
-/// - **Variables**: A numeric identifier prefixed by `$`, e.g. `$0`, `$1`, ... .
+/// - **Variables**: An identifier starting with a upper case ASCII latter followed by zero or more
+///   ASCII letters, digits or underscores, e.g. `X`, `Person`, `FooBar`.
 /// - **Symbols**: An identifier starting with a lower case ASCII latter followed by zero or more
 ///   ASCII letters, digits or underscores, e.g. `foo`, `rightOf`, `is_natural`.
-/// - **Application Terms**: An application of a functor to arguments, e.g. `is_natural($0)` or
-///   `add($0, z, $0)`.
-/// - **Facts**: An application term followed by a dot, e.g. `is_natural(Z).`.
+/// - **Application Terms**: An application of a functor to arguments, e.g. `is_natural(X)` or
+///   `add(X, z, Y)`.
+/// - **Facts**: An application term followed by a dot, e.g. `is_natural(z).`.
 /// - **Rules**: An application term followed by `:-` (a reverse implication arrow) and a comma
-///   separated list of one or more conjunctive conditions, followed by a dot, e.g. `grandparent($0,
-///   $1) :- parent($0, $2), parent($2, $0).`.
+///   separated list of one or more conjunctive conditions, followed by a dot, e.g. `grandparent(A,
+///   B) :- parent(A, C), parent(C, B).`.
 /// - **Queries**: A comma separated list of one or more conjunctive conditions, followed by a dot,
-///   e.g. `grandparent(bob, $0), female($0).`.
+///   e.g. `grandparent(bob, A), female(A).`.
 ///
 /// It doesn't support comments and the moment, so that is probably a good idea for the future.
 ///
@@ -141,22 +53,22 @@ impl Default for NamedUniverse {
 /// u.load_str(
 ///     r#"
 /// is_natural(z).
-/// is_natural(s($0)) :- is_natural($0).
-/// add($0, z, $0) :- is_natural($0).
-/// add($0, s($1), s($2)) :- add($0, $1, $2).
-/// mul($0, z, z) :- is_natural($0).
-/// mul($0, s($1), $2) :- mul($0,$1,$3), add($0,$3,$2).
+/// is_natural(s(A)) :- is_natural(A).
+/// add(A, z, A) :- is_natural(A).
+/// add(A, s(B), s(C)) :- add(A, B, C).
+/// mul(A, z, z) :- is_natural(A).
+/// mul(A, s(B), C) :- mul(A, B, D), add(A, D, C).
 /// "#,
 /// )
 /// .unwrap();
 ///
-/// let query = u.prepare_query("mul($0,$0,$1).").unwrap();
-/// let solutions = query_dfs(u.inner(), &query);
+/// let query = u.prepare_query("mul(X,X,Y).").unwrap();
+/// let solutions = query_dfs(u.rules(), &query);
 /// for solution in solutions.take(5) {
 ///     println!("SOLUTION:");
 ///     for (index, var) in solution.into_iter().enumerate() {
 ///         if let Some(term) = var {
-///             println!("  ${} = {}", index, u.pretty().term_to_string(&term));
+///             println!("  ${} = {}", index, u.pretty().term_to_string(&term, query.scope.as_ref()));
 ///         } else {
 ///             println!("<bug: no solution>");
 ///         }
@@ -165,28 +77,30 @@ impl Default for NamedUniverse {
 /// ```
 ///
 pub struct TextualUniverse {
-    universe: NamedUniverse,
+    symbols: SymbolStore,
+    rules: CompiledRuleDb,
 }
 
 impl TextualUniverse {
     pub fn new() -> Self {
         Self {
-            universe: NamedUniverse::new(),
+            symbols: SymbolStore::new(),
+            rules: CompiledRuleDb::new(),
         }
     }
 
     /// Load a set of rules from a string.
     pub fn load_str(&mut self, rules: &str) -> Result<(), ParseError> {
-        let rules = Parser::new(&mut self.universe).parse_rules_str(rules)?;
+        let rules = Parser::new(&mut self.symbols).parse_rules_str(rules)?;
         for rule in rules {
-            self.universe.inner_mut().add_rule(rule);
+            self.rules.insert(rule);
         }
         Ok(())
     }
 
     /// Parse a query, but do not run it.
     pub fn prepare_query(&mut self, query: &str) -> Result<Query, ParseError> {
-        Parser::new(&mut self.universe).parse_query_str(query)
+        Parser::new(&mut self.symbols).parse_query_str(query)
     }
 
     /// Run a query against the universe using the DFS solver.
@@ -200,27 +114,24 @@ impl TextualUniverse {
     /// thus the pretty-printer is still accessible.
     pub fn query_dfs(&mut self, query: &str) -> Result<SolutionIter, ParseError> {
         let query = self.prepare_query(query)?;
-        Ok(solver::query_dfs(self.universe.inner(), &query))
+        Ok(solver::query_dfs(&self.rules, &query))
     }
 
     // //////////////////////////////// OTHER ACCESSORS ////////////////////////////////
 
     /// Return a pretty-printer using the symbols defined in this universe.
     pub fn pretty(&self) -> Prettifier {
-        Prettifier::new(&self.universe)
+        Prettifier::new(&self.symbols)
     }
 
     /// Return a term parser that uses the name mapping of this universe for parsing terms.
     pub fn parse(&mut self) -> Parser {
-        Parser::new(&mut self.universe)
+        Parser::new(&mut self.symbols)
     }
 
-    pub fn inner_mut(&mut self) -> &mut Universe {
-        self.universe.inner_mut()
-    }
-
-    pub fn inner(&self) -> &Universe {
-        self.universe.inner()
+    /// Return the rules database of this universe.
+    pub fn rules(&self) -> &CompiledRuleDb {
+        &self.rules
     }
 }
 

--- a/src/textual/lexer.rs
+++ b/src/textual/lexer.rs
@@ -1,4 +1,4 @@
-use logos::{Lexer, Logos};
+use logos::Logos;
 
 #[derive(Logos, Debug, PartialEq, Clone)]
 pub enum Token {
@@ -20,17 +20,15 @@ pub enum Token {
     #[regex("[a-z][a-zA-Z_0-9]*")]
     Symbol,
 
-    #[regex(r"\$[0-9]+", lex_variable)]
-    Variable(usize),
+    #[regex("[A-Z][a-zA-Z_0-9]*")]
+    Variable,
+
+    /// NOTE: each wild-card will be a different variable, even when the name is the same.
+    #[regex("_[a-zA-Z_0-9]*")]
+    Wildcard,
 
     // We can also use this variant to define whitespace,
     // or any other matches we wish to skip.
     #[regex(r"[ \t\n\f]+", logos::skip)]
     Whitespace,
-}
-
-fn lex_variable(lex: &mut Lexer<Token>) -> Option<usize> {
-    let slice = lex.slice();
-    let n = slice[1..].parse().ok()?; // skip '$'
-    Some(n)
 }

--- a/testfiles/arithmetic.lru
+++ b/testfiles/arithmetic.lru
@@ -1,8 +1,8 @@
 is_natural(z).
-is_natural(s($0)) :- is_natural($0).
+is_natural(s(X)) :- is_natural(X).
 
-add($0, z, $0) :- is_natural($0).
-add($0, s($1), s($2)) :- add($0, $1, $2).
+add(X, z, X) :- is_natural(X).
+add(X, s(Y), s(Z)) :- add(X, Y, Z).
 
-mul($0, z, z) :- is_natural($0).
-mul($0, s($1), $2) :- mul($0,$1,$3), add($0,$3,$2).
+mul(X, z, z) :- is_natural(X).
+mul(X, s(Y), Z) :- mul(X,Y,W), add(X,W,Z).

--- a/testfiles/zebra-reverse.lru
+++ b/testfiles/zebra-reverse.lru
@@ -1,37 +1,41 @@
-exists($0,list($0,$1,$2,$3,$4)).
-exists($1,list($0,$1,$2,$3,$4)).
-exists($2,list($0,$1,$2,$3,$4)).
-exists($3,list($0,$1,$2,$3,$4)).
-exists($4,list($0,$1,$2,$3,$4)).
-rightOf($1,$0,list($0,$1,$2,$3,$4)).
-rightOf($2,$1,list($0,$1,$2,$3,$4)).
-rightOf($3,$2,list($0,$1,$2,$3,$4)).
-rightOf($4,$3,list($0,$1,$2,$3,$4)).
-middle($2,list($0,$1,$2,$3,$4)).
-first($0,list($0,$1,$2,$3,$4)).
-nextTo($1,$0,list($0,$1,$2,$3,$4)).
-nextTo($2,$1,list($0,$1,$2,$3,$4)).
-nextTo($3,$2,list($0,$1,$2,$3,$4)).
-nextTo($4,$3,list($0,$1,$2,$3,$4)).
-nextTo($0,$1,list($0,$1,$2,$3,$4)).
-nextTo($1,$2,list($0,$1,$2,$3,$4)).
-nextTo($2,$3,list($0,$1,$2,$3,$4)).
-nextTo($3,$4,list($0,$1,$2,$3,$4)).
+exists(A, list(A, _, _, _, _)).
+exists(A, list(_, A, _, _, _)).
+exists(A, list(_, _, A, _, _)).
+exists(A, list(_, _, _, A, _)).
+exists(A, list(_, _, _, _, A)).
 
-puzzle($0) :-
-    exists(house($65,$66,$67,$68,zebra),$0),
-    exists(house($61,$62,water,$63,$64),$0),
-    nextTo(house($53,$54,$55,diplomat,$56),house($57,$58,$59,$60,horse),$0),
-    nextTo(house($45,$46,$47,physician,$48),house($49,$50,$51,$52,fox),$0),
-    exists(house($42,$43,juice,violinist,$44),$0),
-    nextTo(house($13,norway,$14,$15,$16),house(blue,$38,$39,$40,$41),$0),
-    exists(house(green,$35,coffee,$36,$37),$0),
-    middle(house($31,$32,milk,$33,$34),$0),
-    exists(house(yellow,$28,$29,diplomat,$30),$0),
-    exists(house($25,$26,$27,photographer,snails),$0),
-    rightOf(house(green,$17,$18,$19,$20),house(white,$21,$22,$23,$24),$0),
-    first(house($13,norway,$14,$15,$16),$0),
-    exists(house($10,italy,tea,$11,$12),$0),
-    exists(house($7,japan,$8,painter,$9),$0),
-    exists(house($4,spain,$5,$6,dog),$0),
-    exists(house(red,england,$1,$2,$3),$0).
+rightOf(R, L, list(L, R, _, _, _)).
+rightOf(R, L, list(_, L, R, _, _)).
+rightOf(R, L, list(_, _, L, R, _)).
+rightOf(R, L, list(_, _, _, L, R)).
+
+middle(A, list(_, _, A, _, _)).
+
+first(A, list(A, _, _, _, _)).
+
+nextTo(A, B, list(B, A, _, _, _)).
+nextTo(A, B, list(_, B, A, _, _)).
+nextTo(A, B, list(_, _, B, A, _)).
+nextTo(A, B, list(_, _, _, B, A)).
+nextTo(A, B, list(A, B, _, _, _)).
+nextTo(A, B, list(_, A, B, _, _)).
+nextTo(A, B, list(_, _, A, B, _)).
+nextTo(A, B, list(_, _, _, A, B)).
+
+puzzle(Houses) :-
+  exists(house(_, _, _, _, zebra), Houses),
+  exists(house(_, _, water, _, _), Houses),
+  nextTo(house(_, _, _, diplomat, _),house(_, _, _, _, horse), Houses),
+  nextTo(house(_, _, _, physician, _),house(_, _, _, _, fox), Houses),
+  exists(house(_, _, juice, violinist, _), Houses),
+  nextTo(house(_, norway, _, _, _),house(blue, _, _, _, _), Houses),
+  exists(house(green, _, coffee, _, _), Houses),
+  middle(house(_, _, milk, _, _), Houses),
+  exists(house(yellow, _, _, diplomat, _), Houses),
+  exists(house(_, _, _, photographer, snails), Houses),
+  rightOf(house(green, _, _, _, _), house(white, _, _, _, _), Houses),
+  first(house(_, norway, _, _, _), Houses),
+  exists(house(_, italy, tea, _, _), Houses),
+  exists(house(_, japan, _, painter, _), Houses),
+  exists(house(_, spain, _, _, dog), Houses),
+  exists(house(red, england, _, _, _), Houses).

--- a/testfiles/zebra.lru
+++ b/testfiles/zebra.lru
@@ -1,37 +1,41 @@
-exists($0,list($0,$1,$2,$3,$4)).
-exists($1,list($0,$1,$2,$3,$4)).
-exists($2,list($0,$1,$2,$3,$4)).
-exists($3,list($0,$1,$2,$3,$4)).
-exists($4,list($0,$1,$2,$3,$4)).
-rightOf($1,$0,list($0,$1,$2,$3,$4)).
-rightOf($2,$1,list($0,$1,$2,$3,$4)).
-rightOf($3,$2,list($0,$1,$2,$3,$4)).
-rightOf($4,$3,list($0,$1,$2,$3,$4)).
-middle($2,list($0,$1,$2,$3,$4)).
-first($0,list($0,$1,$2,$3,$4)).
-nextTo($1,$0,list($0,$1,$2,$3,$4)).
-nextTo($2,$1,list($0,$1,$2,$3,$4)).
-nextTo($3,$2,list($0,$1,$2,$3,$4)).
-nextTo($4,$3,list($0,$1,$2,$3,$4)).
-nextTo($0,$1,list($0,$1,$2,$3,$4)).
-nextTo($1,$2,list($0,$1,$2,$3,$4)).
-nextTo($2,$3,list($0,$1,$2,$3,$4)).
-nextTo($3,$4,list($0,$1,$2,$3,$4)).
+exists(A, list(A, _, _, _, _)).
+exists(A, list(_, A, _, _, _)).
+exists(A, list(_, _, A, _, _)).
+exists(A, list(_, _, _, A, _)).
+exists(A, list(_, _, _, _, A)).
 
-puzzle($0) :-
-    exists(house(red,england,$1,$2,$3),$0),
-    exists(house($4,spain,$5,$6,dog),$0),
-    exists(house($7,japan,$8,painter,$9),$0),
-    exists(house($10,italy,tea,$11,$12),$0),
-    first(house($13,norway,$14,$15,$16),$0),
-    rightOf(house(green,$17,$18,$19,$20),house(white,$21,$22,$23,$24),$0),
-    exists(house($25,$26,$27,photographer,snails),$0),
-    exists(house(yellow,$28,$29,diplomat,$30),$0),
-    middle(house($31,$32,milk,$33,$34),$0),
-    exists(house(green,$35,coffee,$36,$37),$0),
-    nextTo(house($13,norway,$14,$15,$16),house(blue,$38,$39,$40,$41),$0),
-    exists(house($42,$43,juice,violinist,$44),$0),
-    nextTo(house($45,$46,$47,physician,$48),house($49,$50,$51,$52,fox),$0),
-    nextTo(house($53,$54,$55,diplomat,$56),house($57,$58,$59,$60,horse),$0),
-    exists(house($61,$62,water,$63,$64),$0),
-    exists(house($65,$66,$67,$68,zebra),$0).
+rightOf(R, L, list(L, R, _, _, _)).
+rightOf(R, L, list(_, L, R, _, _)).
+rightOf(R, L, list(_, _, L, R, _)).
+rightOf(R, L, list(_, _, _, L, R)).
+
+middle(A, list(_, _, A, _, _)).
+
+first(A, list(A, _, _, _, _)).
+
+nextTo(A, B, list(B, A, _, _, _)).
+nextTo(A, B, list(_, B, A, _, _)).
+nextTo(A, B, list(_, _, B, A, _)).
+nextTo(A, B, list(_, _, _, B, A)).
+nextTo(A, B, list(A, B, _, _, _)).
+nextTo(A, B, list(_, A, B, _, _)).
+nextTo(A, B, list(_, _, A, B, _)).
+nextTo(A, B, list(_, _, _, A, B)).
+
+puzzle(Houses) :-
+  exists(house(red, england, _, _, _), Houses),
+  exists(house(_, spain, _, _, dog), Houses),
+  exists(house(_, japan, _, painter, _), Houses),
+  exists(house(_, italy, tea, _, _), Houses),
+  first(house(_, norway, _, _, _), Houses),
+  rightOf(house(green, _, _, _, _), house(white, _, _, _, _), Houses),
+  exists(house(_, _, _, photographer, snails), Houses),
+  exists(house(yellow, _, _, diplomat, _), Houses),
+  middle(house(_, _, milk, _, _), Houses),
+  exists(house(green, _, coffee, _, _), Houses),
+  nextTo(house(_, norway, _, _, _),house(blue, _, _, _, _), Houses),
+  exists(house(_, _, juice, violinist, _), Houses),
+  nextTo(house(_, _, _, physician, _),house(_, _, _, _, fox), Houses),
+  nextTo(house(_, _, _, diplomat, _),house(_, _, _, _, horse), Houses),
+  exists(house(_, _, water, _, _), Houses),
+  exists(house(_, _, _, _, zebra), Houses).


### PR DESCRIPTION
Inspired by https://github.com/fatho/logru/pull/12, I finally got around to properly implement named variables, and also overhauled the interface for naming things in general.

---

The universe abstractions were always a bit awkward. They are now split into `SymbolStore`, managing symbol allocations and associated names, and the `CompiledRuleDb`.

There is still the `TextualUniverse` which unifies the previous two types behind a string-based interface.

Variables now also have names, with them being tracked per definition scope (i.e. per rule or query).