### PR TITLE
Simplify resolvers

### DIFF
--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -359,9 +359,9 @@ impl<'s> ReplResolver<'s> {
         args: ArgRange,
         context: &mut logru::search::ResolveContext,
     ) -> Option<Resolved<()>> {
-        let arg_str = args
-            .map(|arg| {
-                let term_id = context.solution().terms().get_arg(arg);
+        let arg_terms = context.solution().terms().get_args(args);
+        let arg_str = arg_terms
+            .map(|term_id| {
                 let term = context.solution().extract_term(term_id);
                 Prettifier::new(self.symbols).term_to_string(&term, self.query_scope)
             })

--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::iter::FromIterator;
 use std::path::PathBuf;
 use std::sync::atomic::{self, AtomicBool};
 use std::sync::Arc;
@@ -330,9 +329,7 @@ impl ReplCommands {
     pub fn new(syms: &mut SymbolStore) -> Self {
         let commands = [("debug", ReplCmd::Debug)];
         Self {
-            goals: HashMap::from_iter(
-                commands.map(|(str, cmd)| (syms.get_or_insert_named(str), cmd)),
-            ),
+            goals: syms.build_sym_map(commands),
         }
     }
 

--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -7,7 +7,7 @@ use std::time::Instant;
 use logru::ast::{Sym, Var, VarScope};
 use logru::resolve::{ArithmeticResolver, ResolverExt};
 use logru::search::{query_dfs, Resolved, Resolver};
-use logru::term_arena::ArgRange;
+use logru::term_arena::{AppTerm, ArgRange};
 use logru::textual::{Prettifier, TextualUniverse};
 use logru::SymbolStore;
 use rustyline::completion::Completer;
@@ -389,7 +389,7 @@ impl<'s> Resolver for ReplResolver<'s> {
         goal_term: logru::term_arena::Term,
         context: &mut logru::search::ResolveContext,
     ) -> Option<Resolved<Self::Choice>> {
-        let (sym, args) = goal_term.as_app()?;
+        let AppTerm(sym, args) = goal_term.as_app()?;
         let goal = self.goals.get(&sym)?;
         match goal {
             ReplCmd::Debug => self.debug(args, context),

--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -386,10 +386,9 @@ impl<'s> Resolver for ReplResolver<'s> {
     fn resolve(
         &mut self,
         _goal_id: logru::term_arena::TermId,
-        goal_term: logru::term_arena::Term,
+        AppTerm(sym, args): logru::term_arena::AppTerm,
         context: &mut logru::search::ResolveContext,
     ) -> Option<Resolved<Self::Choice>> {
-        let AppTerm(sym, args) = goal_term.as_app()?;
         let goal = self.goals.get(&sym)?;
         match goal {
             ReplCmd::Debug => self.debug(args, context),

--- a/examples/zebra.rs
+++ b/examples/zebra.rs
@@ -10,25 +10,29 @@ fn main() {
     u.load_str(include_str!("../testfiles/zebra.lru")).unwrap();
 
     let query = u.prepare_query("puzzle(Houses).").unwrap();
-    for _ in 0..repeats {
+    for i in 0..repeats {
         let search = logru::query_dfs(u.resolver(), &query);
         let before = Instant::now();
         let solutions = search.collect::<Vec<_>>();
         let duration = before.elapsed();
 
         for solution in solutions.iter() {
-            for var in solution {
-                if let Some(term) = var {
-                    println!("{}", u.pretty().term_to_string(term, query.scope.as_ref()));
-                } else {
-                    println!("<bug: no solution>");
+            if i == 0 {
+                for var in solution {
+                    if let Some(term) = var {
+                        println!("{}", u.pretty().term_to_string(term, query.scope.as_ref()));
+                    } else {
+                        println!("<bug: no solution>");
+                    }
                 }
             }
         }
-        println!(
-            "Took {:.3}s with {} solutions",
-            duration.as_secs_f64(),
-            solutions.len()
-        );
+        if i == 0 {
+            println!(
+                "Took {:.3}s with {} solutions",
+                duration.as_secs_f64(),
+                solutions.len()
+            );
+        }
     }
 }

--- a/src/resolve/arithmetic.rs
+++ b/src/resolve/arithmetic.rs
@@ -58,12 +58,8 @@ impl ArithmeticResolver {
         ];
         let preds = [("is", Pred::Is)];
         Self {
-            exp_map: IntoIterator::into_iter(exps)
-                .map(|(name, op)| (symbols.get_or_insert_named(name), op))
-                .collect(),
-            pred_map: IntoIterator::into_iter(preds)
-                .map(|(name, op)| (symbols.get_or_insert_named(name), op))
-                .collect(),
+            exp_map: symbols.build_sym_map(exps),
+            pred_map: symbols.build_sym_map(preds),
         }
     }
 

--- a/src/resolve/arithmetic.rs
+++ b/src/resolve/arithmetic.rs
@@ -133,10 +133,9 @@ impl Resolver for ArithmeticResolver {
     fn resolve(
         &mut self,
         _goal_id: crate::term_arena::TermId,
-        goal_term: crate::term_arena::Term,
+        AppTerm(sym, args): crate::term_arena::AppTerm,
         context: &mut crate::search::ResolveContext,
     ) -> Option<Resolved<Self::Choice>> {
-        let AppTerm(sym, args) = goal_term.as_app()?;
         let pred = self.pred_map.get(&sym)?;
         match pred {
             Pred::Is => self.resolve_is(args, context),

--- a/src/resolve/combinators.rs
+++ b/src/resolve/combinators.rs
@@ -37,7 +37,7 @@ impl<R1: Resolver, R2: Resolver> Resolver for OrElse<R1, R2> {
     fn resolve(
         &mut self,
         goal_id: term_arena::TermId,
-        goal_term: term_arena::Term,
+        goal_term: term_arena::AppTerm,
         context: &mut ResolveContext,
     ) -> Option<Resolved<Self::Choice>> {
         self.first

--- a/src/resolve/rules.rs
+++ b/src/resolve/rules.rs
@@ -33,6 +33,8 @@ impl<'a> RuleResolver<'a> {
             .instantiate_blueprint(head_blueprint, var_offset);
         let instantiated_rule_head = conv_rule_head(head);
 
+        // TODO: simplify things even more so that we can use the argument ranges directly for
+        // unification, since we already know at this point that the head symbols match.
         if solution.unify(goal_term, instantiated_rule_head) {
             // instantiate tail terms
             let (tail, tail_blueprint) = rule.tail();
@@ -73,10 +75,9 @@ impl<'a> Resolver for RuleResolver<'a> {
     fn resolve(
         &mut self,
         goal_id: term_arena::TermId,
-        goal_term: term_arena::Term,
+        AppTerm(sym, _): term_arena::AppTerm,
         context: &mut ResolveContext,
     ) -> Option<Resolved<Self::Choice>> {
-        let AppTerm(sym, _) = goal_term.as_app()?;
         let rules = self.rules.rules_by_head(sym);
         let rest = self.apply_first_rule(rules, goal_id, context)?;
         if rest.is_empty() {

--- a/src/resolve/rules.rs
+++ b/src/resolve/rules.rs
@@ -74,22 +74,14 @@ impl<'a> Resolver for RuleResolver<'a> {
         goal_id: term_arena::TermId,
         goal_term: term_arena::Term,
         context: &mut ResolveContext,
-    ) -> Resolved<Self::Choice> {
-        if let term_arena::Term::App(sym, _) = goal_term {
-            let rules = self.rules.rules_by_head(sym);
-            if let Some(rest) = self.apply_first_rule(rules, goal_id, context) {
-                if rest.is_empty() {
-                    Resolved::Success
-                } else {
-                    Resolved::SuccessRetry(rest)
-                }
-            } else {
-                Resolved::Fail
-            }
+    ) -> Option<Resolved<Self::Choice>> {
+        let (sym, _) = goal_term.as_app()?;
+        let rules = self.rules.rules_by_head(sym);
+        let rest = self.apply_first_rule(rules, goal_id, context)?;
+        if rest.is_empty() {
+            Some(Resolved::Success)
         } else {
-            // Reject all other terms as potential goals in this resolver
-            // That way, eventually another resolver may pick them up.
-            Resolved::Fail
+            Some(Resolved::SuccessRetry(rest))
         }
     }
 

--- a/src/resolve/rules.rs
+++ b/src/resolve/rules.rs
@@ -1,4 +1,5 @@
 use crate::search::{ResolveContext, Resolved, Resolver, SolutionState};
+use crate::term_arena::AppTerm;
 use crate::universe::CompiledRule;
 use crate::{term_arena, RuleSet};
 
@@ -75,7 +76,7 @@ impl<'a> Resolver for RuleResolver<'a> {
         goal_term: term_arena::Term,
         context: &mut ResolveContext,
     ) -> Option<Resolved<Self::Choice>> {
-        let (sym, _) = goal_term.as_app()?;
+        let AppTerm(sym, _) = goal_term.as_app()?;
         let rules = self.rules.rules_by_head(sym);
         let rest = self.apply_first_rule(rules, goal_id, context)?;
         if rest.is_empty() {

--- a/src/search.rs
+++ b/src/search.rs
@@ -481,8 +481,7 @@ impl SolutionState {
                 }
                 term_arena::Term::App(_, args) => {
                     let terms = &self.terms;
-                    self.occurs_stack
-                        .extend(args.map(|arg_id| terms.get_arg(arg_id)))
+                    self.occurs_stack.extend(terms.get_args(args))
                 }
                 // Primitive values cannot contain variables
                 term_arena::Term::Int(_) => {}
@@ -529,8 +528,10 @@ impl SolutionState {
             }
             term_arena::Term::App(functor, args) => ast::Term::App(ast::AppTerm {
                 functor,
-                args: args
-                    .map(|arg_id| self.extract_term(self.terms.get_arg(arg_id)))
+                args: self
+                    .terms
+                    .get_args(args)
+                    .map(|arg| self.extract_term(arg))
                     .collect(),
             }),
             term_arena::Term::Int(i) => ast::Term::Int(i),

--- a/src/search.rs
+++ b/src/search.rs
@@ -479,7 +479,7 @@ impl SolutionState {
                         continue;
                     }
                 }
-                term_arena::Term::App(_, args) => {
+                term_arena::Term::App(term_arena::AppTerm(_, args)) => {
                     let terms = &self.terms;
                     self.occurs_stack.extend(terms.get_args(args))
                 }
@@ -526,14 +526,16 @@ impl SolutionState {
                     ast::Term::Var(v)
                 }
             }
-            term_arena::Term::App(functor, args) => ast::Term::App(ast::AppTerm {
-                functor,
-                args: self
-                    .terms
-                    .get_args(args)
-                    .map(|arg| self.extract_term(arg))
-                    .collect(),
-            }),
+            term_arena::Term::App(term_arena::AppTerm(functor, args)) => {
+                ast::Term::App(ast::AppTerm {
+                    functor,
+                    args: self
+                        .terms
+                        .get_args(args)
+                        .map(|arg| self.extract_term(arg))
+                        .collect(),
+                })
+            }
             term_arena::Term::Int(i) => ast::Term::Int(i),
         }
     }
@@ -599,8 +601,8 @@ impl SolutionState {
             (_, term_arena::Term::Var(rule_var)) => self.set_var(rule_var, goal_term_id),
             // two application terms
             (
-                term_arena::Term::App(goal_func, goal_args),
-                term_arena::Term::App(rule_func, rule_args),
+                term_arena::Term::App(term_arena::AppTerm(goal_func, goal_args)),
+                term_arena::Term::App(term_arena::AppTerm(rule_func, rule_args)),
             ) => {
                 // the terms must have the same functor symbol and the same arity
                 if goal_func != rule_func {

--- a/src/term_arena.rs
+++ b/src/term_arena.rs
@@ -336,3 +336,21 @@ pub enum Term {
     /// A signed 64-bit integer
     Int(i64),
 }
+
+impl Term {
+    /// If this term is [`Term::Int`], return the enclosed integer.
+    pub fn as_int(self) -> Option<i64> {
+        match self {
+            Term::Int(i) => Some(i),
+            _ => None,
+        }
+    }
+
+    /// If this term is [`Term::App`] return the symbol and arguments.
+    pub fn as_app(self) -> Option<(Sym, ArgRange)> {
+        match self {
+            Term::App(sym, args) => Some((sym, args)),
+            _ => None,
+        }
+    }
+}

--- a/src/term_arena.rs
+++ b/src/term_arena.rs
@@ -359,24 +359,6 @@ pub enum Term {
     Int(i64),
 }
 
-impl Term {
-    /// If this term is [`Term::Int`], return the enclosed integer.
-    pub fn as_int(self) -> Option<i64> {
-        match self {
-            Term::Int(i) => Some(i),
-            _ => None,
-        }
-    }
-
-    /// If this term is [`Term::App`] return the symbol and arguments.
-    pub fn as_app(self) -> Option<AppTerm> {
-        match self {
-            Term::App(app) => Some(app),
-            _ => None,
-        }
-    }
-}
-
 /// An application term of the form `foo(arg1, arg2, arg3, ...)` that is part of a [`TermArena`].
 /// The argument range can be used to get the corresponding argument terms from the arena.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/universe.rs
+++ b/src/universe.rs
@@ -70,6 +70,18 @@ impl SymbolStore {
         })
     }
 
+    /// Given a list of name-value pairs, translate the names into [`Sym`]s and return a mapping
+    /// from symbols to values.
+    pub fn build_sym_map<'a, T>(
+        &mut self,
+        pairs: impl IntoIterator<Item = (&'a str, T)>,
+    ) -> HashMap<Sym, T> {
+        pairs
+            .into_iter()
+            .map(|(name, value)| (self.get_or_insert_named(name), value))
+            .collect()
+    }
+
     /// Generate a fresh unnamed symbol ID in this universe.
     ///
     /// # Notes


### PR DESCRIPTION
Simplify building resolvers by
- returning an `Option` from the `resolve` function, which allows shortcutting with `?`
- providing a helper function for reserving symbols used by custom resolvers
- providing helper functions for easier access to the arguments of app terms
- passing an app term directly to `resolve`, since only app terms are eligible for being "called" as predicates.