### PR TITLE
Parse line comments behind %

### DIFF
--- a/src/textual/lexer.rs
+++ b/src/textual/lexer.rs
@@ -37,6 +37,9 @@ pub enum Token {
     // or any other matches we wish to skip.
     #[regex(r"[ \t\n\f]+", logos::skip)]
     Whitespace,
+
+    #[regex(r"%.*", logos::skip)]
+    LineComment,
 }
 
 fn parse_int(lex: &mut Lexer<Token>) -> Option<i64> {

--- a/src/textual/parser.rs
+++ b/src/textual/parser.rs
@@ -312,3 +312,36 @@ fn test_rule_parsing() {
     rule_roundtrip_test("is_natural(s(X)) :- is_natural(X).");
     rule_roundtrip_test("grandparent(X, Y) :- parent(X, Z), parent(Z, Y).");
 }
+
+#[test]
+fn test_comment_parsing() {
+    let mut nu = SymbolStore::new();
+    let mut p = Parser::new(&mut nu);
+    let with_comment = p.parse_rule_str("foo. % example comment").unwrap();
+    let no_comment = p.parse_rule_str("foo.").unwrap();
+    assert_eq!(with_comment, no_comment);
+    let with_comment = p.parse_rule_str("foo. % bar.").unwrap();
+    assert_eq!(with_comment, no_comment);
+
+    let no_comment = p
+        .parse_rules_str(
+            "foo.
+bar.",
+        )
+        .unwrap();
+    let with_comment = p
+        .parse_rules_str(
+            "foo. % comment
+bar.",
+        )
+        .unwrap();
+    assert_eq!(with_comment, no_comment);
+    let with_comment = p
+        .parse_rules_str(
+            "%comment
+foo.
+bar.",
+        )
+        .unwrap();
+    assert_eq!(with_comment, no_comment);
+}

--- a/testfiles/arithmetic.lru
+++ b/testfiles/arithmetic.lru
@@ -1,3 +1,4 @@
+% Arithmetics test
 is_natural(z).
 is_natural(s(X)) :- is_natural(X).
 


### PR DESCRIPTION
I'm not sure how to add a unit test for the comment being alone on the line, given that it defines no rule.