### PR TITLE
immutable Universe

### DIFF
--- a/examples/arithmetic.rs
+++ b/examples/arithmetic.rs
@@ -7,7 +7,7 @@ fn main() {
         .unwrap();
 
     let query = u.prepare_query("mul(A,A,B).").unwrap();
-    let solutions = query_dfs(u.resolver(), &query);
+    let solutions = query_dfs(u.resolver(), query.query());
 
     for solution in solutions.take(10) {
         println!("SOLUTION:");
@@ -16,7 +16,8 @@ fn main() {
                 println!(
                     "  ${} = {}",
                     var.ord(),
-                    u.pretty().term_to_string(&term, query.scope.as_ref())
+                    u.pretty()
+                        .term_to_string(&term, query.query().scope.as_ref())
                 );
             } else {
                 println!("<bug: no solution>");

--- a/examples/zebra.rs
+++ b/examples/zebra.rs
@@ -11,7 +11,7 @@ fn main() {
 
     let query = u.prepare_query("puzzle(Houses).").unwrap();
     for i in 0..repeats {
-        let search = logru::query_dfs(u.resolver(), &query);
+        let search = logru::query_dfs(u.resolver(), query.query());
         let before = Instant::now();
         let solutions = search.collect::<Vec<_>>();
         let duration = before.elapsed();
@@ -20,7 +20,11 @@ fn main() {
             if i == 0 {
                 for var in solution.vars() {
                     if let Some(term) = var {
-                        println!("{}", u.pretty().term_to_string(term, query.scope.as_ref()));
+                        println!(
+                            "{}",
+                            u.pretty()
+                                .term_to_string(term, query.query().scope.as_ref())
+                        );
                     } else {
                         println!("<bug: no solution>");
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@
 //!
 //! ```
 //! use logru::ast::{self, Rule};
+//! use logru::SymbolStorage;
 //!
 //! let mut syms = logru::SymbolStore::new();
 //! let mut r = logru::RuleSet::new();
@@ -84,6 +85,7 @@
 //! # use logru::ast::{self, Rule};
 //! # use logru::resolve::RuleResolver;
 //! # use logru::search::Solution;
+//! # use logru::SymbolStorage;
 //! # let mut syms = logru::SymbolStore::new();
 //! # let mut r = logru::RuleSet::new();
 //! # let s = syms.get_or_insert_named("s");
@@ -154,4 +156,4 @@ pub mod universe;
 
 pub use resolve::RuleResolver;
 pub use search::query_dfs;
-pub use universe::{RuleSet, SymbolStore};
+pub use universe::{RuleSet, SymbolStorage, SymbolStore, Symbols};

--- a/src/search.rs
+++ b/src/search.rs
@@ -113,6 +113,7 @@ impl<'c> ResolveContext<'c> {
     }
 }
 
+#[derive(Debug)]
 pub enum Resolved<C> {
     /// The goal resolved to a single choice that was successfully applied to the state.
     Success,
@@ -284,6 +285,7 @@ impl<R: Resolver> SolutionIter<R> {
     /// # use logru::ast::{self, Rule};
     /// # use logru::resolve::RuleResolver;
     /// # use logru::search::Step;
+    /// # use logru::SymbolStorage;
     /// # let mut syms = logru::SymbolStore::new();
     /// # let mut r = logru::RuleSet::new();
     /// # let s = syms.get_or_insert_named("s");

--- a/src/search/test.rs
+++ b/src/search/test.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::textual::TextualUniverse;
-use crate::{ast::*, RuleResolver, RuleSet, SymbolStore};
+use crate::{ast::*, RuleResolver, RuleSet, SymbolStorage, SymbolStore};
 
 #[test]
 fn genealogy() {
@@ -237,15 +237,17 @@ fn cut() {
     #[track_caller]
     fn assert_solutions(tu: &mut TextualUniverse, query: &str, solutions: &[&[Option<&str>]]) {
         let query = tu.prepare_query(query).unwrap();
-        let rets: Vec<_> = query_dfs(tu.resolver(), &query).collect();
+        let rets: Vec<_> = query_dfs(tu.resolver(), query.query()).collect();
         let pretty_solutions: Vec<_> = rets
             .into_iter()
             .map(|sol| {
                 sol.vars()
                     .iter()
                     .map(|var| {
-                        var.as_ref()
-                            .map(|term| tu.pretty().term_to_string(&term, query.scope.as_ref()))
+                        var.as_ref().map(|term| {
+                            tu.pretty()
+                                .term_to_string(&term, query.query().scope.as_ref())
+                        })
                     })
                     .collect::<Vec<_>>()
             })

--- a/src/textual/parser.rs
+++ b/src/textual/parser.rs
@@ -291,7 +291,7 @@ mod test {
     }
 
     #[test]
-    fn test_query_parsing() {
+    fn query_parsing() {
         query_roundtrip_test("grandparent(bob, X).");
         query_roundtrip_test("grandparent(bob, X), female(X).");
 
@@ -309,14 +309,14 @@ mod test {
     }
 
     #[test]
-    fn test_rule_parsing() {
+    fn rule_parsing() {
         rule_roundtrip_test("is_natural(z).");
         rule_roundtrip_test("is_natural(s(X)) :- is_natural(X).");
         rule_roundtrip_test("grandparent(X, Y) :- parent(X, Z), parent(Z, Y).");
     }
 
     #[test]
-    fn test_comment_parsing() {
+    fn comment_parsing() {
         let mut nu = SymbolStore::new();
         let mut p = Parser::new(&mut nu);
         let with_comment = p.parse_rule_str("foo. % example comment").unwrap();

--- a/src/textual/parser.rs
+++ b/src/textual/parser.rs
@@ -276,72 +276,75 @@ impl<'a> Parser<'a> {
 }
 
 #[cfg(test)]
-fn query_roundtrip_test(input: &str) {
-    let mut nu = SymbolStore::new();
-    let mut p = Parser::new(&mut nu);
+mod test {
+    use super::super::pretty;
+    use super::*;
+    fn query_roundtrip_test(input: &str) {
+        let mut nu = SymbolStore::new();
+        let mut p = Parser::new(&mut nu);
 
-    let q = p.parse_query_str(input).unwrap();
+        let q = p.parse_query_str(input).unwrap();
 
-    let pretty = super::pretty::Prettifier::new(&nu);
-    let qs = pretty.query_to_string(&q);
-    assert_eq!(qs, input);
-}
+        let pretty = pretty::Prettifier::new(&nu);
+        let qs = pretty.query_to_string(&q);
+        assert_eq!(qs, input);
+    }
 
-#[test]
-fn test_query_parsing() {
-    query_roundtrip_test("grandparent(bob, X).");
-    query_roundtrip_test("grandparent(bob, X), female(X).");
+    #[test]
+    fn test_query_parsing() {
+        query_roundtrip_test("grandparent(bob, X).");
+        query_roundtrip_test("grandparent(bob, X), female(X).");
 
-    query_roundtrip_test("add(s(s(s(s(z)))), s(s(z)), X).");
-}
+        query_roundtrip_test("add(s(s(s(s(z)))), s(s(z)), X).");
+    }
 
-#[cfg(test)]
-fn rule_roundtrip_test(input: &str) {
-    let mut nu = SymbolStore::new();
-    let mut p = Parser::new(&mut nu);
-    let q = p.parse_rule_str(input).unwrap();
+    fn rule_roundtrip_test(input: &str) {
+        let mut nu = SymbolStore::new();
+        let mut p = Parser::new(&mut nu);
+        let q = p.parse_rule_str(input).unwrap();
 
-    let pretty = super::pretty::Prettifier::new(&nu);
-    let qs = pretty.rule_to_string(&q);
-    assert_eq!(qs, input);
-}
+        let pretty = pretty::Prettifier::new(&nu);
+        let qs = pretty.rule_to_string(&q);
+        assert_eq!(qs, input);
+    }
 
-#[test]
-fn test_rule_parsing() {
-    rule_roundtrip_test("is_natural(z).");
-    rule_roundtrip_test("is_natural(s(X)) :- is_natural(X).");
-    rule_roundtrip_test("grandparent(X, Y) :- parent(X, Z), parent(Z, Y).");
-}
+    #[test]
+    fn test_rule_parsing() {
+        rule_roundtrip_test("is_natural(z).");
+        rule_roundtrip_test("is_natural(s(X)) :- is_natural(X).");
+        rule_roundtrip_test("grandparent(X, Y) :- parent(X, Z), parent(Z, Y).");
+    }
 
-#[test]
-fn test_comment_parsing() {
-    let mut nu = SymbolStore::new();
-    let mut p = Parser::new(&mut nu);
-    let with_comment = p.parse_rule_str("foo. % example comment").unwrap();
-    let no_comment = p.parse_rule_str("foo.").unwrap();
-    assert_eq!(with_comment, no_comment);
-    let with_comment = p.parse_rule_str("foo. % bar.").unwrap();
-    assert_eq!(with_comment, no_comment);
+    #[test]
+    fn test_comment_parsing() {
+        let mut nu = SymbolStore::new();
+        let mut p = Parser::new(&mut nu);
+        let with_comment = p.parse_rule_str("foo. % example comment").unwrap();
+        let no_comment = p.parse_rule_str("foo.").unwrap();
+        assert_eq!(with_comment, no_comment);
+        let with_comment = p.parse_rule_str("foo. % bar.").unwrap();
+        assert_eq!(with_comment, no_comment);
 
-    let no_comment = p
-        .parse_rules_str(
-            "foo.
-bar.",
-        )
-        .unwrap();
-    let with_comment = p
-        .parse_rules_str(
-            "foo. % comment
-bar.",
-        )
-        .unwrap();
-    assert_eq!(with_comment, no_comment);
-    let with_comment = p
-        .parse_rules_str(
-            "%comment
-foo.
-bar.",
-        )
-        .unwrap();
-    assert_eq!(with_comment, no_comment);
+        let no_comment = p
+            .parse_rules_str(
+                "foo.
+    bar.",
+            )
+            .unwrap();
+        let with_comment = p
+            .parse_rules_str(
+                "foo. % comment
+    bar.",
+            )
+            .unwrap();
+        assert_eq!(with_comment, no_comment);
+        let with_comment = p
+            .parse_rules_str(
+                "%comment
+    foo.
+    bar.",
+            )
+            .unwrap();
+        assert_eq!(with_comment, no_comment);
+    }
 }

--- a/src/textual/pretty.rs
+++ b/src/textual/pretty.rs
@@ -1,15 +1,16 @@
-use crate::ast::{AppTerm, Query, Rule, Term, VarScope};
-
-use super::SymbolStore;
+use crate::{
+    ast::{AppTerm, Query, Rule, Term, VarScope},
+    universe::Symbols,
+};
 
 /// A pretty-printer for terms using the Prolog-like syntax of the
 /// [TextualUniverse](super::TextualUniverse).
-pub struct Prettifier<'u> {
-    universe: &'u SymbolStore,
+pub struct Prettifier<'u, T: Symbols> {
+    universe: &'u T,
 }
 
-impl<'a> Prettifier<'a> {
-    pub fn new(universe: &'a SymbolStore) -> Self {
+impl<'a, T: Symbols> Prettifier<'a, T> {
+    pub fn new(universe: &'a T) -> Self {
         Self { universe }
     }
 

--- a/src/universe.rs
+++ b/src/universe.rs
@@ -1,6 +1,6 @@
 //! # Universe
 //!
-//! The universe consists of two main "databases" that are relevant to the set of facts, rules and
+//! The universe consists of two main "databases" that are relevant to the set of facts", "databases" that are relevant to the set of facts"),rules and
 //! queries:
 //! 1. The [`SymbolStore`] is used for allocating named and unnamed [`Sym`]bols which are used as
 //!    identifiers in the low-level representation.
@@ -11,6 +11,44 @@ use crate::{
     ast::*,
     term_arena::{self, TermArena},
 };
+
+/// A modifiable collection of symbols
+pub trait SymbolStorage {
+    /// Return the symbol associated with the name, or allocate a fresh ID and associate it with the
+    /// given name.
+    fn get_or_insert_named(&mut self, name: &str) -> Sym;
+
+    /// Given a list of name-value pairs, translate the names into [`Sym`]s and return a mapping
+    /// from symbols to values.
+    fn build_sym_map<'a, T>(
+        &mut self,
+        pairs: impl IntoIterator<Item = (&'a str, T)>,
+    ) -> HashMap<Sym, T> {
+        pairs
+            .into_iter()
+            .map(|(name, value)| (self.get_or_insert_named(name), value))
+            .collect()
+    }
+}
+
+impl<T> SymbolStorage for &mut T
+where
+    T: SymbolStorage,
+{
+    fn get_or_insert_named(&mut self, name: &str) -> Sym {
+        let this: &mut T = *self; // Specify the concrete type to call to avoid accidentally recursing back into this method and creating an infinite loop.
+        this.get_or_insert_named(name)
+    }
+}
+
+/// A readable collection of symbols
+pub trait Symbols {
+    /// Get the name of a symbol, if it has one.
+    fn get_symbol_name(&self, sym: Sym) -> Option<&str>;
+
+    /// Returns the number of symbols that have been allocated in this universe.
+    fn num_symbols(&self) -> usize;
+}
 
 /// The symbol store is responsible for allocating unique [`Sym`]s (unique within the instance,
 /// there are no guardrails preventing mixing [`Sym`]s from different [`SymbolStore`]s), and keeps a
@@ -40,7 +78,7 @@ use crate::{
 /// # Example
 ///
 /// See the [top-level example](crate#example).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SymbolStore {
     /// Mapping from names to symbols
     sym_by_name: HashMap<Arc<str>, Sym>,
@@ -58,30 +96,6 @@ impl SymbolStore {
         }
     }
 
-    /// Return the symbol associated with the name, or allocate a fresh ID and associate it with the
-    /// given name.
-    pub fn get_or_insert_named(&mut self, name: &str) -> Sym {
-        self.sym_by_name.get(name).copied().unwrap_or_else(|| {
-            let sym = Sym::from_ord(self.name_by_sym.len());
-            let shared_name: Arc<str> = name.into();
-            self.name_by_sym.push(Some(shared_name.clone()));
-            self.sym_by_name.insert(shared_name, sym);
-            sym
-        })
-    }
-
-    /// Given a list of name-value pairs, translate the names into [`Sym`]s and return a mapping
-    /// from symbols to values.
-    pub fn build_sym_map<'a, T>(
-        &mut self,
-        pairs: impl IntoIterator<Item = (&'a str, T)>,
-    ) -> HashMap<Sym, T> {
-        pairs
-            .into_iter()
-            .map(|(name, value)| (self.get_or_insert_named(name), value))
-            .collect()
-    }
-
     /// Generate a fresh unnamed symbol ID in this universe.
     ///
     /// # Notes
@@ -94,21 +108,85 @@ impl SymbolStore {
         self.name_by_sym.push(None);
         sym
     }
+}
 
+impl Symbols for SymbolStore {
     /// Get the name of a symbol, if it has one.
-    pub fn get_symbol_name(&self, sym: Sym) -> Option<&str> {
+    fn get_symbol_name(&self, sym: Sym) -> Option<&str> {
         self.name_by_sym.get(sym.ord()).and_then(|n| n.as_deref())
     }
 
     /// Returns the number of symbols that have been allocated in this universe.
-    pub fn num_symbols(&self) -> usize {
+    fn num_symbols(&self) -> usize {
         self.name_by_sym.len()
+    }
+}
+
+impl<'a> SymbolStorage for SymbolStore {
+    /// Return the symbol associated with the name, or allocate a fresh ID and associate it with the
+    /// given name.
+    fn get_or_insert_named(&mut self, name: &str) -> Sym {
+        self.sym_by_name.get(name).copied().unwrap_or_else(|| {
+            let sym = Sym::from_ord(self.name_by_sym.len());
+            let shared_name: Arc<str> = name.into();
+            self.name_by_sym.push(Some(shared_name.clone()));
+            self.sym_by_name.insert(shared_name, sym);
+            sym
+        })
     }
 }
 
 impl Default for SymbolStore {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Stores and allocates unique symbols on top of a symbol store, without modifying it.
+#[derive(Debug)]
+pub struct SymbolOverlay<'a> {
+    symbols: &'a SymbolStore,
+    // Sym entries stored here start at 0, but get translated on the API boundary to start at symbols.num_symbols().
+    overlay: SymbolStore,
+}
+
+impl<'a> SymbolOverlay<'a> {
+    pub fn new(symbols: &'a SymbolStore) -> Self {
+        Self {
+            symbols,
+            overlay: Default::default(),
+        }
+    }
+}
+
+impl SymbolStorage for SymbolOverlay<'_> {
+    /// Return the symbol associated with the name, or allocate a fresh ID and associate it with the
+    /// given name.
+    fn get_or_insert_named(&mut self, name: &str) -> Sym {
+        self.symbols
+            .sym_by_name
+            .get(name)
+            .copied()
+            .unwrap_or_else(|| {
+                Sym::from_ord(
+                    self.symbols.num_symbols() + self.overlay.get_or_insert_named(name).ord(),
+                )
+            })
+    }
+}
+
+impl Symbols for SymbolOverlay<'_> {
+    /// Get the name of a symbol, if it has one.
+    fn get_symbol_name(&self, sym: Sym) -> Option<&str> {
+        match sym.ord().checked_sub(self.symbols.num_symbols()) {
+            None => self.symbols.get_symbol_name(sym),
+            Some(index) => self.overlay.get_symbol_name(Sym::from_ord(index)),
+        }
+    }
+
+    /// Returns the number of symbols that have been allocated in this universe.
+    fn num_symbols(&self) -> usize {
+        self.overlay.num_symbols() + self.symbols.num_symbols()
     }
 }
 
@@ -236,5 +314,52 @@ impl RuleSet {
 impl Default for RuleSet {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{ast::Sym, Symbols};
+
+    use super::{SymbolOverlay, SymbolStorage, SymbolStore};
+
+    #[test]
+    fn overlay() {
+        let mut plain = SymbolStore::new();
+        plain.insert_unnamed();
+        plain.insert_unnamed();
+        plain.insert_unnamed();
+        plain.get_or_insert_named("a");
+        let overlay_copy = plain.clone();
+        let mut overlaid = SymbolOverlay::new(&overlay_copy);
+
+        assert_eq!(
+            plain.get_or_insert_named("b"),
+            overlaid.get_or_insert_named("b")
+        );
+
+        assert_eq!(
+            plain.get_or_insert_named("c"),
+            overlaid.get_or_insert_named("c")
+        );
+
+        assert_eq!(plain.num_symbols(), overlaid.num_symbols());
+
+        assert_eq!(
+            plain.get_symbol_name(Sym::from_ord(3)),
+            overlaid.get_symbol_name(Sym::from_ord(3))
+        );
+
+        // WARNING: those two checks are overly strict: they check that SymbolOverlay and SymbolStore assign the same numbers to additional symbols. That is not pat of the contract for an Overlay, although it makes debugging and testing easier.
+        // If the need arises to relax the constraint, check instead that newly added symbols don't collide with existing ones and that names can be obtained correctly.
+        assert_eq!(
+            plain.get_symbol_name(Sym::from_ord(5)),
+            overlaid.get_symbol_name(Sym::from_ord(5))
+        );
+
+        assert_eq!(
+            plain.get_symbol_name(Sym::from_ord(99)),
+            overlaid.get_symbol_name(Sym::from_ord(99))
+        );
     }
 }


### PR DESCRIPTION
Using Queries is currently awkward because creating them requires a &mut Universe. In my case, this means either a RefCell on the database which wraps Universe.

This pushes errors from compile-time to runtime, which is not so great.

I looked into creating the Query, and the only thing the &mut is for is to put additional symbols in the symbols store. This gave me the idea: why not bundle symbols with the Query and call it the UniverseQuery?

```
struct UniverseQuery {
  symbols: Symbols,
  query: Query,
}
```

This makes the original Universe obsolete for this query, but the problems with &mut are gone.

In this patch, I decided that the original Universe doesn't have to be copied with every query, so I sketched the type for a lighter SymbolsOverlay:

```
struct SymbolsOverlay {
  symbols: &SymbolsStore, // lots of symbols
  overlay: SymbolsStore, // only symbols from this query
}
```

and I stopped there so far.

Does this look like a good direction?