### PR TITLE
Run CI on PRs and check documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,5 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Check documentation
+      run: RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace --document-private-items --examples --bins --lib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: Build and test
 # This workflow is triggered on pushes to the repository.
-on: [push]
+on: [push, pull_request]
 
 
 env:


### PR DESCRIPTION
To keep the docs up to date, check on CI that it can be generated without errors (such as stale links).
Also include the `pull_request` trigger for the CI workflow so that it can be run on PRs from forks (or so I hope).