### PR TITLE
RFC: Arithmetics

### DIFF
--- a/examples/arithmetic.rs
+++ b/examples/arithmetic.rs
@@ -13,12 +13,7 @@ fn main() {
         println!("SOLUTION:");
         for (var, term) in solution.iter_vars() {
             if let Some(term) = term {
-                println!(
-                    "  ${} = {}",
-                    var.ord(),
-                    u.pretty()
-                        .term_to_string(term, query.query().scope.as_ref())
-                );
+                println!("  ${} = {}", var.ord(), query.pretty().term_to_string(term));
             } else {
                 println!("<bug: no solution>");
             }

--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -171,13 +171,7 @@ fn query(state: &mut AppState, args: &str) {
                                 print!("  _{} = ", var.ord());
                             }
                             if let Some(term) = term {
-                                println!(
-                                    "{}",
-                                    state
-                                        .universe
-                                        .pretty()
-                                        .term_to_string(term, query.query().scope.as_ref())
-                                );
+                                println!("{}", query.pretty().term_to_string(term));
                             } else {
                                 println!("<any>");
                             }

--- a/examples/zebra.rs
+++ b/examples/zebra.rs
@@ -20,11 +20,7 @@ fn main() {
             if i == 0 {
                 for var in solution.vars() {
                     if let Some(term) = var {
-                        println!(
-                            "{}",
-                            u.pretty()
-                                .term_to_string(term, query.query().scope.as_ref())
-                        );
+                        println!("{}", query.pretty().term_to_string(term));
                     } else {
                         println!("<bug: no solution>");
                     }

--- a/src/search/test.rs
+++ b/src/search/test.rs
@@ -243,12 +243,7 @@ fn cut() {
             .map(|sol| {
                 sol.vars()
                     .iter()
-                    .map(|var| {
-                        var.as_ref().map(|term| {
-                            tu.pretty()
-                                .term_to_string(term, query.query().scope.as_ref())
-                        })
-                    })
+                    .map(|var| var.as_ref().map(|term| query.pretty().term_to_string(term)))
                     .collect::<Vec<_>>()
             })
             .collect();

--- a/src/textual.rs
+++ b/src/textual.rs
@@ -8,6 +8,7 @@ mod parser;
 mod pretty;
 
 pub use parser::{ParseError, ParseErrorKind};
+use pretty::ScopedPrettifier;
 
 use crate::{
     ast::Query,
@@ -69,7 +70,7 @@ pub use self::{parser::Parser, pretty::Prettifier};
 ///     println!("SOLUTION:");
 ///     for (var, term) in solution.iter_vars() {
 ///         if let Some(term) = term {
-///             println!("  ${} = {}", var.ord(), u.pretty().term_to_string(&term, query.query().scope.as_ref()));
+///             println!("  ${} = {}", var.ord(), query.pretty().term_to_string(&term));
 ///         } else {
 ///             println!("<bug: no solution>");
 ///         }
@@ -169,5 +170,11 @@ impl<'a> UniverseQuery<'a> {
 
     pub fn symbols_mut(&mut self) -> &mut SymbolOverlay<'a> {
         &mut self.symbols
+    }
+
+    /// Return a pretty-printer using the symbols defined in this query.
+    /// As opposed to TextualUniverse::pretty, this one won't allow any mixups between the sources of the universe and the variables.
+    pub fn pretty(&self) -> ScopedPrettifier<SymbolOverlay> {
+        ScopedPrettifier::new(&self.symbols, self.query().scope.as_ref())
     }
 }

--- a/src/textual/pretty.rs
+++ b/src/textual/pretty.rs
@@ -2,9 +2,12 @@ use crate::{
     ast::{AppTerm, Query, Rule, Term, VarScope},
     universe::Symbols,
 };
+use std::ops::Deref;
 
 /// A pretty-printer for terms using the Prolog-like syntax of the
 /// [TextualUniverse](super::TextualUniverse).
+///
+/// This type takes an explicit scope in many methods, making it possible to use the wrong variable scope for the given universe. A version where mixups are impossible is ScopedPrettifier.
 pub struct Prettifier<'u, T: Symbols> {
     universe: &'u T,
 }
@@ -114,5 +117,52 @@ impl<'a, T: Symbols> Prettifier<'a, T> {
             self.pretty_conjunction(writer, &rule.tail, rule.scope.as_ref())?;
         }
         Ok(())
+    }
+}
+
+/// A prettifier for showing terms relating to a query.
+pub struct ScopedPrettifier<'u, T: Symbols> {
+    pretty: Prettifier<'u, T>,
+    // The scope is meant to reference the same query as the symbols in the base prettifier, so it shares the lifetime
+    scope: Option<&'u VarScope>,
+}
+
+impl<'u, T: Symbols> ScopedPrettifier<'u, T> {
+    pub fn new(universe: &'u T, scope: Option<&'u VarScope>) -> Self {
+        Self {
+            pretty: Prettifier::new(universe),
+            scope,
+        }
+    }
+
+    pub fn term_to_string(&self, term: &Term) -> String {
+        self.pretty.term_to_string(term, self.scope)
+    }
+
+    pub fn pretty<W: std::fmt::Write>(&self, writer: &mut W, term: &Term) -> std::fmt::Result {
+        self.pretty.pretty(writer, term, self.scope)
+    }
+
+    pub fn pretty_app<W: std::fmt::Write>(
+        &self,
+        writer: &mut W,
+        term: &AppTerm,
+    ) -> std::fmt::Result {
+        self.pretty.pretty_app(writer, term, self.scope)
+    }
+
+    pub fn pretty_conjunction<W: std::fmt::Write>(
+        &self,
+        writer: &mut W,
+        goals: &[Term],
+    ) -> std::fmt::Result {
+        self.pretty.pretty_conjunction(writer, goals, self.scope)
+    }
+}
+
+impl<'u, T: Symbols> Deref for ScopedPrettifier<'u, T> {
+    type Target = Prettifier<'u, T>;
+    fn deref(&self) -> &Self::Target {
+        &self.pretty
     }
 }

--- a/src/universe.rs
+++ b/src/universe.rs
@@ -143,7 +143,7 @@ impl Default for SymbolStore {
 }
 
 /// Stores and allocates unique symbols on top of a symbol store, without modifying it.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SymbolOverlay<'a> {
     symbols: &'a SymbolStore,
     // Sym entries stored here start at 0, but get translated on the API boundary to start at symbols.num_symbols().


### PR DESCRIPTION
I gave it a try and added some arithmetics that are going to be required by my use case.

Unlike the existing ones, those I added are all predicates. They all require full instantiation, apart from IsNeg, which will negate an integer if not out of bounds.

Initially I wanted to make the predicates fill in variables with matching values, but that quickly leads to i64-sized loops.

While I don't expect logru to support clp(fd), I think there's a continuum of ways to make arithmetics resolve to something useful. With one variable, the syntax could look like:

```
is(Var, and(condition, ...)).
```

where the resolver could look at all conditions to see if they are bounded before proceeding.

Does that sound like anything desireable?

* * *

Another thing is the lack of messages when there's a variable which is not instantiated enough. I epect that to be the main thing driving people away. I could give it a shot and change impl Resolver to return an error message, and pass it all the way to the user. Interested?