### PR TITLE
Count variable occurrences

### DIFF
--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -1,0 +1,32 @@
+//! Program analysis proceduress
+
+use crate::ast::{Rule, Term, Var};
+use std::collections::{HashMap, HashSet};
+
+/// Finds variables occuring only once in the rule (together in head and tail).
+pub fn find_unique_variables(rule: &Rule) -> HashSet<Var> {
+    let vars = count_variables(rule);
+    vars.into_iter()
+        .filter(|(_var, count)| *count == 1)
+        .map(|(var, _count)| var)
+        .collect()
+}
+
+/// Counts the number of occurrences of all variables in the rule (both in head and tail).
+pub fn count_variables(rule: &Rule) -> HashMap<Var, usize> {
+    let mut vars = HashMap::new();
+    count_in_args(&mut vars, &rule.head.args);
+    count_in_args(&mut vars, &rule.tail);
+    vars
+}
+
+fn count_in_args(mut vars: &mut HashMap<Var, usize>, args: &[Term]) {
+    for term in args {
+        match term {
+            Term::Var(var) => *vars.entry(*var).or_insert(0) += 1,
+            Term::Int(_) => {}
+            Term::Cut => {}
+            Term::App(appterm) => count_in_args(&mut vars, &appterm.args),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,6 +152,7 @@
 #[cfg(doctest)]
 pub struct ReadmeDoctests;
 
+pub mod analysis;
 pub mod ast;
 pub mod resolve;
 pub mod search;

--- a/src/textual.rs
+++ b/src/textual.rs
@@ -11,7 +11,7 @@ pub use parser::{ParseError, ParseErrorKind};
 use pretty::ScopedPrettifier;
 
 use crate::{
-    ast::Query,
+    ast::{Query, Rule},
     resolve::RuleResolver,
     search::{self, SolutionIter},
     universe::{RuleSet, SymbolOverlay, SymbolStore},
@@ -91,12 +91,22 @@ impl TextualUniverse {
         }
     }
 
-    /// Load a set of rules from a string.
-    pub fn load_str(&mut self, rules: &str) -> Result<(), ParseError> {
-        let rules = Parser::new(&mut self.symbols).parse_rules_str(rules)?;
+    /// Parse a set of rules using the symbols defined in this universe.
+    pub fn parse_rules(&mut self, rules: &str) -> Result<Vec<Rule>, ParseError> {
+        Parser::new(&mut self.symbols).parse_rules_str(rules)
+    }
+
+    /// Insert rules previously parsed using [`Self::parse_rules`].
+    pub fn insert_rules(&mut self, rules: Vec<Rule>) {
         for rule in rules {
             self.rules.insert(rule);
         }
+    }
+
+    /// Load a set of rules from a string.
+    pub fn load_str(&mut self, rules: &str) -> Result<(), ParseError> {
+        let rules = self.parse_rules(rules)?;
+        self.insert_rules(rules);
         Ok(())
     }
 


### PR DESCRIPTION
This helps find typos, because logru otherwise doesn't warn about underspecified variables.

This is a quick and simple prototype.

Things that could be done differently:
- abstracting VarScope into a trait, although it's probably overkill
- VarScope.name is made public. Not sure what other interface should be used to copy one. `::new(Vec<_>)` or `::from_iter`? And then `::empty()` for creating an empty one.
- currently it's just a `println`. `tracing::warn` would be another "worse is better" solution, but tracing is not imported by logru. Otherwise this could turn into a warning interface, but I didn't want to go into that rabbit hole before getting a general approval.